### PR TITLE
make oldconfig

### DIFF
--- a/support/build-toolchain.sh
+++ b/support/build-toolchain.sh
@@ -22,6 +22,7 @@ if [ -f ~/trimuismart-toolchain.tar.xz ]; then
  	tar -xf ~/trimuismart-toolchain.tar.xz -C /opt
 else
 	export FORCE_UNSAFE_CONFIGURE=1
+	make oldconfig
 	make world
 
 	mkdir -p /opt/trimuismart-toolchain


### PR DESCRIPTION
fix error at docker build.

```
#11 19.32 nvme (BR2_PACKAGE_NVME) [N/y/?] n
#11 19.32 ofono (BR2_PACKAGE_OFONO) [N/y/?] n
#11 19.32 ola (open lighting architecture) (BR2_PACKAGE_OLA) [N/y/?] (NEW) aborted!
#11 19.32
#11 19.32 Console input/output is redirected. Run 'make oldconfig' to update configuration.
#11 19.32
#11 19.33 make[1]: *** [silentoldconfig] Error 1
#11 19.33 Makefile:836: recipe for target 'silentoldconfig' failed
#11 19.33 make[1]: Leaving directory '/root/buildroot'
#11 19.33 Makefile:487: recipe for target '/root/buildroot/output/build/buildroot-config/auto.conf' failed
#11 19.33 make: *** [/root/buildroot/output/build/buildroot-config/auto.conf] Error 2
------
executor failed running [/bin/sh -c ./build-toolchain.sh]: exit code: 2
make: *** [.build] Error 1
```

build environment kernel.

macOS Monterey 12.6.1

```
$ uname -a
Darwin example.local 21.6.0 Darwin Kernel Version 21.6.0: Thu Sep 29 20:12:57 PDT 2022; root:xnu-8020.240.7~1/RELEASE_X86_64 x86_64
```